### PR TITLE
[Resolve #43] Add configuration for flexsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,40 @@ async function processSuggestions(suggestions: Suggestion[], queryString: string
  */
 async function onGoToSuggestion(index: number, suggestion: Suggestion, queryString: string, queryTerms: string[]): Boolean?
 ```
+
+### Additional configuration
+
+You can set additional configuration options in the config file. For `tokenize`, `split`, and
+`encode`, see the [flexsearch documentation][flexsearch-options] for more details.
+
+* `tokenize`: The indexing mode (tokenizer). Choose one of the built-ins or pass a custom tokenizer
+  function.
+* `split`: The rule to split words when using non-custom tokenizer (built-ins e.g. "forward"). Use a
+  string/char or use a regular expression (default: `/\W+/`).
+* `encode`: The encoding type. Choose one of the built-ins or pass a custom encoding function.
+
+The built-in `searchMaxSuggestions` will be used if set in the
+[theme config][search-max-suggestions].
+
+For example:
+
+```js
+module.exports = {
+  plugins: [
+    [
+      'fulltext-search',
+      {
+        tokenize: 'full',
+        split: /\s+/,
+        encode: 'icase',
+      },
+    ],
+  ],
+  themeConfig: {
+    searchMaxSuggestions: 10,
+  }
+}
+```
+
+[flexsearch-options]: [https://github.com/nextapps-de/flexsearch#initialize-index]
+[search-max-suggestions]: https://vuepress.vuejs.org/theme/default-theme-config.html#built-in-search

--- a/components/SearchBox.vue
+++ b/components/SearchBox.vue
@@ -88,8 +88,10 @@ export default {
       this.getSuggestions()
     },
   },
+  /* global OPTIONS */
   mounted() {
-    flexsearchSvc.buildIndex(this.$site.pages)
+    const options = OPTIONS || {};
+    flexsearchSvc.buildIndex(this.$site.pages, options)
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
     document.addEventListener('keydown', this.onHotkey)
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ module.exports = (options, ctx, globalCtx) => ({
       content: options.hooks || 'export default {}',
     }
   },
+  define() {
+    return {
+      OPTIONS: options,
+    }
+  },
 })
 
 function normalizeText(text) {

--- a/services/flexsearchSvc.js
+++ b/services/flexsearchSvc.js
@@ -12,11 +12,12 @@ let pagesByPath = null
 const cjkRegex = /[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]|[\u4E00-\u9FCC\u3400-\u4DB5\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29]|[\ud840-\ud868][\udc00-\udfff]|\ud869[\udc00-\uded6\udf00-\udfff]|[\ud86a-\ud86c][\udc00-\udfff]|\ud86d[\udc00-\udf34\udf40-\udfff]|\ud86e[\udc00-\udc1d]|[\u3041-\u3096]|[\u30A1-\u30FA]/giu
 
 export default {
-  buildIndex(allPages) {
+  buildIndex(allPages, options) {
     const pages = allPages.filter(p => !p.frontmatter || p.frontmatter.search !== false)
     const indexSettings = {
-      encode: 'simple',
-      tokenize: 'forward',
+      encode: options.encode || 'simple',
+      tokenize: options.tokenize || 'forward',
+      split: options.split || /\W+/,
       async: true,
       doc: {
         id: 'key',


### PR DESCRIPTION
Add pass-through options for configuring flexsearch. This allows more customization for how the search behaves.

Also add documentation for these options and the `searchMaxSuggestions` configuration.