### PR TITLE
Change global variable name to avoid conflicts

### DIFF
--- a/components/SearchBox.vue
+++ b/components/SearchBox.vue
@@ -88,9 +88,9 @@ export default {
       this.getSuggestions()
     },
   },
-  /* global OPTIONS */
+  /* global FULLTEXT_SEARCH_OPTIONS */
   mounted() {
-    const options = OPTIONS || {}
+    const options = FULLTEXT_SEARCH_OPTIONS || {}
     flexsearchSvc.buildIndex(this.$site.pages, options)
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
     document.addEventListener('keydown', this.onHotkey)

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = (options, ctx, globalCtx) => ({
   },
   define() {
     return {
-      OPTIONS: options,
+      FULLTEXT_SEARCH_OPTIONS: options,
     }
   },
 })


### PR DESCRIPTION
The `OPTIONS` name is too generic, and runs into conflicts with some other plugins.