### PR TITLE
Only return results that are relevant to current locale

### DIFF
--- a/components/SearchBox.vue
+++ b/components/SearchBox.vue
@@ -91,7 +91,7 @@ export default {
   /* global OPTIONS */
   mounted() {
     const options = OPTIONS || {}
-    flexsearchSvc.buildIndex(this.$site.pages, options)
+    flexsearchSvc.buildIndex(this.$site.pages, options, this.$localePath)
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
     document.addEventListener('keydown', this.onHotkey)
 

--- a/services/flexsearchSvc.js
+++ b/services/flexsearchSvc.js
@@ -12,8 +12,9 @@ let pagesByPath = null
 const cjkRegex = /[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]|[\u4E00-\u9FCC\u3400-\u4DB5\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29]|[\ud840-\ud868][\udc00-\udfff]|\ud869[\udc00-\uded6\udf00-\udfff]|[\ud86a-\ud86c][\udc00-\udfff]|\ud86d[\udc00-\udf34\udf40-\udfff]|\ud86e[\udc00-\udc1d]|[\u3041-\u3096]|[\u30A1-\u30FA]/giu
 
 export default {
-  buildIndex(allPages, options) {
-    const pages = allPages.filter(p => !p.frontmatter || p.frontmatter.search !== false)
+  buildIndex(allPages, options, localePath) {
+    const pages = allPages.filter(p => !p.frontmatter || p.frontmatter.search !== false && (p.path.startsWith(localePath) || p.path === '/'))
+    
     const indexSettings = {
       encode: options.encode || 'simple',
       tokenize: options.tokenize || 'forward',


### PR DESCRIPTION
Fixes #27

This fix ensures that if you're in a multi-lingual document your search shows only the terms in the current language. This is particularly important when not all pages are translated, as it ensures the untranslated English version doesn't show up multiple times.

All it does is pass in the current locale, then check whether the current page location starts with that locale. I have tested this for Chinese and English pages, which start with /zh/ and /en/ respectively. It works fine when you are in those pages BUT does not work if you switch from English to Chinese (say) because it is only initialised when the page is first loaded. Still, much better for me than the current version.